### PR TITLE
Fix parsing for 0 length arguments

### DIFF
--- a/src/cmd/goredis/main.rl
+++ b/src/cmd/goredis/main.rl
@@ -52,7 +52,7 @@ var cs int
 
   redis_argnum = '*' ( digit @argnum_add_digit )+ '\r\n';
   redis_argsize = '$' @argsize_reset ( digit @argsize_add_digit )+ '\r\n';
-  redis_arg = (any when test_arg_len @arg_add_char)+ '\r\n';
+  redis_arg = (any when test_arg_len @arg_add_char)* '\r\n';
   redis_cmd = redis_argnum @args_init ( redis_argsize @arg_init redis_arg )+;
 
   main := redis_cmd;


### PR DESCRIPTION
Broke it out into a separate module for testing...

Fixes one of the issues from issue #1, I guess discarding the "QUIT" command might actually be better done elsewhere as it's not actually part of the protocol

```
=== RUN TestParseOK
--- PASS: TestParseOK (0.00 seconds)
    parser_test.go:37: *4
        $5
        SETEX
        $6
        e:ntry
        $2
        30
        $2
        hi
         parsed ok
    parser_test.go:37: *4
        $5
        SETEX
        $6
        e:ntry
        $2
        30
        $0

         parsed ok
PASS
ok      goredis/parser  0.004s
```
